### PR TITLE
Add docker SDK image to SDK resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,14 @@ A "no-code alternative to the full SDK", Pulp provides a "click-and-place" game 
 ##### Playdate SDK
 Panic publishes two versions of their SDK: a high-level API for Lua, similar to LÖVE, and a lower-level C library for applications with higher performance needs.
 
+###### Official
 - [Playdate SDK Lua Documentation](https://sdk.play.date/inside-playdate)
 - [Playdate SDK C Documentation](https://sdk.play.date/inside-playdate-with-c)
 - [Develop for Playdate](https://play.date/dev/)
-- [Install with Package Managers](https://gist.github.com/idleberg/e246f7a582ac173d156c60ec23ce2af0)
-- [Playdate SDK and Docker](https://github.com/hjhart/playdate-docker)
+
+###### Unofficial
+- [Install Playdate SDK with Package Managers](https://gist.github.com/idleberg/e246f7a582ac173d156c60ec23ce2af0)
+- [Playdate SDK Docker Image](https://github.com/hjhart/playdate-docker)
 
 
 ###### Playdate SDK Previews

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Panic publishes two versions of their SDK: a high-level API for Lua, similar to 
 - [Playdate SDK C Documentation](https://sdk.play.date/inside-playdate-with-c)
 - [Develop for Playdate](https://play.date/dev/)
 - [Install with Package Managers](https://gist.github.com/idleberg/e246f7a582ac173d156c60ec23ce2af0)
+- [Playdate SDK and Docker](https://github.com/hjhart/playdate-docker)
+
 
 ###### Playdate SDK Previews
 - [Playdate Programming LIVE](https://www.youtube.com/watch?v=MZRtfiD_308&t=2629s) - 50 minute long programming demo that shows some of the SDK and simulator.


### PR DESCRIPTION
Not an official docker image, but something I whipped together I've been using. This could facilitate some good stuff later on, like allowing an engineer to develop inside of an environment like GitHub codespaces or AWSs equivalent.